### PR TITLE
Fixing incorrect max height config usage

### DIFF
--- a/src/w11k-select.directive.ts
+++ b/src/w11k-select.directive.ts
@@ -184,7 +184,7 @@ export function w11kSelect(w11kSelectConfig, $parse, $document, w11kSelectHelper
 
         function adjustHeight() {
           if (angular.isDefined(scope.config.style.maxHeight)) {
-            domDropDownContent.style.maxHeight = scope.style.maxHeight;
+            domDropDownContent.style.maxHeight = scope.config.style.maxHeight;
           }
           else {
             let maxHeight = calculateDynamicMaxHeight();


### PR DESCRIPTION
Directive was correctly checking for the presence of a max height in
the config at scope.config.style.maxHeight, but was then attempting to
use scope.style.maxHeight, which fails as it doesn’t exist.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug Fix

* **What is the current behavior?** (You can also link to an open issue here)

Using max height configuration parameter causes RTE as the wrong scope path is being referenced.

* **What is the new behavior (if this is a feature change)?**

Fixed scope path reference. Max height now works. 

* **Other information**:
