### PR TITLE
Amending updateStaticTexts to accept empty strings

### DIFF
--- a/src/w11k-select.directive.ts
+++ b/src/w11k-select.directive.ts
@@ -140,17 +140,17 @@ export function w11kSelect(w11kSelectConfig, $parse, $document, w11kSelectHelper
         }
 
         function updateStaticTexts() {
-          if (scope.config.filter.select.active && scope.config.filter.select.text) {
+          if (scope.config.filter.select.active && scope.config.filter.select.text !== null && typeof(scope.config.filter.select.text) !== 'undefined') {
             let selectFilteredButton = domElement.querySelector('.select-filtered-text');
             selectFilteredButton.textContent = scope.config.filter.select.text;
           }
 
-          if (scope.config.filter.deselect.active && scope.config.filter.deselect.text) {
+          if (scope.config.filter.deselect.active && scope.config.filter.deselect.text !== null && typeof(scope.config.filter.deselect.text) !== 'undefined') {
             let deselectFilteredButton = domElement.querySelector('.deselect-filtered-text');
             deselectFilteredButton.textContent = scope.config.filter.deselect.text;
           }
 
-          if (scope.config.header.placeholder) {
+          if (scope.config.header.placeholder !== null && typeof(scope.config.header.placeholder) !== 'undefined') {
             let headerPlaceholder = domElement.querySelector('.header-placeholder');
             headerPlaceholder.textContent = scope.config.header.placeholder;
           }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

As written, the updateStaticTexts function does a simple boolean check
against string configurations. This means that an empty string, a valid
input, is interpreted as a false, and the text is not applied to the
static text field. 

* **What is the new behavior (if this is a feature change)?**

If statements have been amended to check for null
and undefined explicitly instead of implicitly.

* **Other information**:
