### PR TITLE
Provide nullable model config option

### DIFF
--- a/src/model/config.model.ts
+++ b/src/model/config.model.ts
@@ -87,6 +87,8 @@ export class ConfigInstance {
   };
   /** when set to true, the clear-button is always visible. */
   showClearAlways: boolean = false;
+  /** when set to true, we force the view value and external value to be null rather than undefined when 0 options are selected */
+  useNullableModel: boolean = false;
   children: string;
 
 }

--- a/src/w11k-select.directive.ts
+++ b/src/w11k-select.directive.ts
@@ -516,7 +516,7 @@ export function w11kSelect (w11kSelectConfig: Config,
 
           if (angular.isArray(modelValue)) {
             viewValue = modelValue;
-          } else if (angular.isDefined(modelValue)) {
+          } else if (angular.isDefined(modelValue) && !(scope.config.useNullableModel && modelValue === null)) {
             viewValue = [modelValue];
           } else {
             viewValue = [];

--- a/src/w11k-select.directive.ts
+++ b/src/w11k-select.directive.ts
@@ -466,15 +466,25 @@ export function w11kSelect (w11kSelectConfig: Config,
         function setViewValue () {
           let selectedValues = internalOptions2externalModel(internalOptions, optionsExpParsed, w11kSelectConfig);
 
-          controller.$setViewValue(selectedValues);
+          let newViewValue: null|any[] = selectedValues;
+
+          if (scope.config.useNullableModel && selectedValues.length === 0) {
+            newViewValue = null;
+          }
+
+          controller.$setViewValue(newViewValue);
           updateHeader();
         }
 
         function updateNgModel () {
-          let value = internalOptions2externalModel(internalOptions, optionsExpParsed, w11kSelectConfig);
+          let value: null|any[] = internalOptions2externalModel(internalOptions, optionsExpParsed, w11kSelectConfig);
           angular.forEach(controller.$parsers, function (parser) {
             value = parser(value);
           });
+
+          if (scope.config.useNullableModel && (typeof value === 'undefined' || value.length === 0)) {
+            value = null;
+          }
 
           ngModelSetter(scope.$parent, value);
         }
@@ -518,6 +528,8 @@ export function w11kSelect (w11kSelectConfig: Config,
         function internal2external (viewValue) {
           if (angular.isUndefined(viewValue)) {
             return;
+          } else if (scope.config.useNullableModel && viewValue === null) {
+            return null;
           }
 
           let modelValue;
@@ -550,7 +562,7 @@ export function w11kSelect (w11kSelectConfig: Config,
 
         function isEmpty () {
           let value = controller.$viewValue;
-          return !(angular.isArray(value) && value.length > 0);
+          return !(angular.isArray(value) && value.length > 0) || (scope.config.useNullableModel && value === null);
         }
 
         scope.isEmpty = isEmpty;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix / feature

* **What is the current behavior?** (You can also link to an open issue here)

w11k-select currently does not allow for ng-model to use null values for single select binding, in or out. When binding in, a null is added as a value to the internal selected value array, and when binding out, zero selections provides a value of 'undefined' to the external variable.

This creates situations where it is difficult or impossible to correctly detect if a value has changed outside of w11k-select.

* **What is the new behavior (if this is a feature change)?**

This PR provides a new config option, 'useNullableModel', and allows user to selectively fix the issue without affecting prior implementations of w11k-select. This config option is defaulted to false, preserving the existing undefined output of the project for existing usage, but permitting new usage, including my own, to use a nullable model.

If a property bound into w11k-select's ng-model has a null value, w11k-select will correctly interpret that as "no selection", not as "one selection of null". Additionally, if a user deselects all options in a single select, the ng-model binding will provide a null value to the bound property.

* **Other information**:

Discussed in #45.
